### PR TITLE
Wait for postgres to start for root user

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -3,7 +3,12 @@
 sudo -u circleci initdb -D /usr/local/pgsql/data
 sudo -u circleci pg_ctl start -D /usr/local/pgsql/data
 sleep 1 # wait for pg to start up
-sudo -u circleci createuser root --createdb --superuser
+for (( i=1; i<30; i++ ))
+do 
+  sudo -u circleci createuser root --createdb --superuser && break
+  echo "createuser retry: "$i
+  sleep 1
+done
 
 # Start redis.
 redis-server --daemonize yes


### PR DESCRIPTION
Dearest Review, 

My bash scripting has withered away to nothing. This should try
for 30 seconds to create the root user for postgres while postgres
tries to start.

Becker