### PR TITLE
brackets are bash 3 feature

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -3,8 +3,8 @@
 sudo -u circleci initdb -D /usr/local/pgsql/data
 sudo -u circleci pg_ctl start -D /usr/local/pgsql/data
 sleep 1 # wait for pg to start up
-for i in {1..30}
-do 
+for i in 1 2 3 4 5 6 7 8 9 10 11
+do
   sudo -u circleci createuser root --createdb --superuser && break
   echo "createuser retry: $i"
   sleep 1


### PR DESCRIPTION
Dear Reviewer

I read not to use seq command so I am doing a hand coded list of
retry values (standard syntax). The catch does work
`createuser retry: {1..30}` from the circle log

Becker