### PR TITLE
DEVOPS-470 update ruby version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5
+FROM ruby:2.6.6-buster
 
 WORKDIR /
 


### PR DESCRIPTION
This updates the Ruby version for the CircleCI docker image.