### PR TITLE
DEVOPS-501-4: Upgrade aha-circle-docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Run `docker build .`
 
 Pushing to GitHub will start an image build on CodeBuild which puts an image in ECR tagged with the commit digest. Update the CircleCI config in a project to use this new digest.
 
+### Forcing a build
+
+Sometimes you need to upgrade a package to a new minor version, but you can only specify the major version in the Dockerfile.  In cases like this, simply trigger a rebuild of the package in CodeBuild.
+
+To do this, log on to the AWS Console for this project and click Start Build; don't forget to elevate your privileges first. Once the build completes, the resulting image will get tagged with the SHA of the previous image which means any project referencing that SHA will use the new image.
+
 ## Testing
 
 I use Kitematic GUI.


### PR DESCRIPTION
There&#x27;s really nothing to change here, we just need to trigger a new build which will cause the latest node 12.22.1 to be included, something that I confirmed with a local build. But we need to update the README with instructions on how to do this.

Changes: add instructions on how to force a rebuild